### PR TITLE
Fix for issue https://github.com/Mapwize/mapwize-ui-android/issues/11

### DIFF
--- a/mapwizeui/src/main/java/io/mapwize/mapwizecomponents/ui/SearchDirectionView.java
+++ b/mapwizeui/src/main/java/io/mapwize/mapwizecomponents/ui/SearchDirectionView.java
@@ -20,6 +20,7 @@ import android.widget.Toast;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.indoorlocation.core.IndoorLocation;
 import io.mapwize.mapwizecomponents.R;
 import io.mapwize.mapwizeformapbox.api.Api;
 import io.mapwize.mapwizeformapbox.api.ApiCallback;
@@ -236,7 +237,12 @@ public class SearchDirectionView extends ConstraintLayout implements
             mapwizePlugin.removePromotedPlace((Place) fromDirectionPoint);
         }
         if (directionPoint == null) {
-            fromDirectionPoint = new MapwizeIndoorLocation(mapwizePlugin.getUserPosition());
+            IndoorLocation userPosition = mapwizePlugin.getUserPosition();
+            if (userPosition == null) {
+                fromEditText.setText(null);
+                return;
+            }
+            fromDirectionPoint = new MapwizeIndoorLocation(userPosition);
             fromEditText.setText(getResources().getString(R.string.current_location));
         }
         else if (directionPoint instanceof MapwizeIndoorLocation){
@@ -266,7 +272,12 @@ public class SearchDirectionView extends ConstraintLayout implements
             mapwizePlugin.removePromotedPlace((Place) toDirectionPoint);
         }
         if (directionPoint == null) {
-            toDirectionPoint = new MapwizeIndoorLocation(mapwizePlugin.getUserPosition());
+            IndoorLocation userPosition = mapwizePlugin.getUserPosition();
+            if (userPosition == null) {
+                toEditText.setText(null);
+                return;
+            }
+            toDirectionPoint = new MapwizeIndoorLocation(userPosition);
             toEditText.setText(getResources().getString(R.string.current_location));
         }
         else if (directionPoint instanceof MapwizeIndoorLocation){


### PR DESCRIPTION
Suggested fix for issue https://github.com/Mapwize/mapwize-ui-android/issues/11 When swapping directions, one of them is null and user position is not available then nullify edit text.

PR information 
- NPE fixed
- If the user types some text into the direction field and this is not a place then it will be cleared after swap execution. To swap also text from editText, bigger refactor is required -> pass latest editText values as param to method setTo/FromDirectionPoint(Object directionPoint, String to/from)