### PR TITLE
Use the main color for the loader on Search bar and on Search results

### DIFF
--- a/mapwize-ui/src/main/res/layout/mapwize_search_bar.xml
+++ b/mapwize-ui/src/main/res/layout/mapwize_search_bar.xml
@@ -3,9 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:paddingTop="8dp"
-    android:paddingEnd="8dp"
-    android:paddingStart="8dp"
+    android:padding="8dp"
     android:clipToPadding="false"
     android:focusable="true"
     android:focusableInTouchMode="true"
@@ -89,6 +87,8 @@
                     android:id="@+id/mapwizeSearchBarProgressBar"
                     android:layout_width="48dp"
                     android:layout_height="48dp"
+                    android:progressTint="@color/mapwize_main_color"
+                    android:indeterminateTint="@color/mapwize_main_color"
                     android:visibility="gone"/>
             </FrameLayout>
 
@@ -96,15 +96,5 @@
 
     </androidx.cardview.widget.CardView>
 
-    <ProgressBar
-        android:id="@+id/mapwizeResultListProgress"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="0dp"
-        android:layout_height="8dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/mapwizeSearchBarCardView"
-        android:indeterminate="true"
-        android:visibility="invisible"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mapwize-ui/src/main/res/layout/mapwize_search_results_list.xml
+++ b/mapwize-ui/src/main/res/layout/mapwize_search_results_list.xml
@@ -19,6 +19,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:indeterminateTint="@color/mapwize_main_color"
+        android:progressTint="@color/mapwize_main_color"
         android:indeterminate="true"
         android:visibility="invisible"/>
 


### PR DESCRIPTION
- This uses the mapwize main color on Search bar and on Search Results.
- Unused Progress bar with the identifier `mapwizeResultListProgress` was safely deleted.