### PR TITLE
fix: check if the MapwizeMap is loaded before asking for user location

### DIFF
--- a/mapwize-ui/src/main/java/io/mapwize/mapwizeui/MapPresenter.java
+++ b/mapwize-ui/src/main/java/io/mapwize/mapwizeui/MapPresenter.java
@@ -304,6 +304,9 @@ public class MapPresenter implements BasePresenter, MapwizeMap.OnVenueEnterListe
     }
 
     public void onFollowUserModeButtonClick() {
+        if (mapwizeMap == null) {
+            return;
+        }
         if (mapwizeMap.getUserLocation() == null) {
             fragment.dispatchFollowUserModeWithoutLocation();
         }


### PR DESCRIPTION
This fixes a crash when the user clicks on the `FollowUserButton` while the map is still loading.